### PR TITLE
fix: fix swedish language

### DIFF
--- a/src/locale/sv.js
+++ b/src/locale/sv.js
@@ -1,7 +1,10 @@
 module.exports = (i) => {
   const hour = i.hour()
-  if (hour >= 4 && hour < 18) {
-    return 'Dobrý deň%s' // (4:00 - 17:59)
+  if (hour >= 4 && hour < 11) {
+    return 'God morgon%s' // (4:00 - 10:59)
   }
-  return 'Dobrý večer%s'
+  if (hour >= 11 && hour < 20) {
+    return 'Goddag%s' // (11:00 - 19:59)
+  }
+  return 'God kväll%s'
 }

--- a/test/sv.test.js
+++ b/test/sv.test.js
@@ -7,14 +7,19 @@ dayjs.extend(greetPlugin)
 
 it('Greet in SV', () => {
   dayjs.locale('sv')
-  expect(dayjs('2022-07-07 04:00:00').greet()).toBe('Dobrý deň')
-  expect(dayjs('2022-07-07 17:59:59').greet()).toBe('Dobrý deň')
-  expect(dayjs('2022-07-07 17:59:59').greet(' custom suffix')).toBe(
-    'Dobrý deň custom suffix'
+  expect(dayjs('2022-07-07 04:00:00').greet()).toBe('God morgon')
+  expect(dayjs('2022-07-07 10:59:59').greet()).toBe('God morgon')
+  expect(dayjs('2022-07-07 10:59:59').greet(' custom suffix')).toBe(
+    'God morgon custom suffix'
   )
-  expect(dayjs('2022-07-07 18:00:00').greet()).toBe('Dobrý večer')
-  expect(dayjs('2022-07-07 03:59:59').greet()).toBe('Dobrý večer')
+  expect(dayjs('2022-07-07 11:00:00').greet()).toBe('Goddag')
+  expect(dayjs('2022-07-07 19:59:59').greet()).toBe('Goddag')
+  expect(dayjs('2022-07-07 19:59:59').greet(' custom suffix')).toBe(
+    'Goddag custom suffix'
+  )
+  expect(dayjs('2022-07-07 20:00:00').greet()).toBe('God kväll')
+  expect(dayjs('2022-07-07 03:59:59').greet()).toBe('God kväll')
   expect(dayjs('2022-07-07 03:59:59').greet(' custom suffix')).toBe(
-    'Dobrý večer custom suffix'
+    'God kväll custom suffix'
   )
 })


### PR DESCRIPTION
`sv` language code must have been interpreted as Slovenian or similar, but it is actually Swedish